### PR TITLE
Add simple http server for local testing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,4 +5,7 @@ build: node_modules
 node_modules: package.json
 	npm install
 
-.PHONY: build
+serve:
+	(cd doc && python3 -m 'http.server' 666)
+
+.PHONY: build serve

--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,13 @@
 
 # se19
 
-Webbplatsen madr.se. För att regenerera alla dokument, kör
+The site https://madr.se, a swedish personal site.
+
+## Build site
 
     $ make build
+
+
+## Run build locally
+
+    $ make serve


### PR DESCRIPTION
Add a simple HTTP server, running on port 666, to test the build.

Autoreload or restart on changes are not necessary.