### PR TITLE
Add Make target for brutal legend app import

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,4 +8,11 @@ node_modules: package.json
 serve:
 	(cd doc && python3 -m 'http.server' 666)
 
-.PHONY: build serve
+brutal-legend:
+	(cd ../practical-redux && npm run build)
+	mkdir doc/bl
+	cp ../practical-redux/index.html doc/bl/index.html
+	cp ../practical-redux/bundle.js doc/bl/bundle.js
+	cp -r ../practical-redux/assets doc/bl/assets
+
+.PHONY: brutal-legend build serve


### PR DESCRIPTION
Asuming git project is cloned at ../practical-redux, for coincedential reasons and lazyness.

Solves #15 